### PR TITLE
Add challenge 2 - GET /tasks

### DIFF
--- a/example_solutions/challenge_2.rb
+++ b/example_solutions/challenge_2.rb
@@ -1,0 +1,5 @@
+require "sinatra"
+
+get "/**" do
+  [200, '{ "tasks": [] }']
+end

--- a/simulation/ChallengeStack.pde
+++ b/simulation/ChallengeStack.pde
@@ -5,6 +5,7 @@ class ChallengeStack {
   ChallengeStack() {
     challengeStack = new ArrayList<Challenge>();
     challengeStack.add(new Challenge_200Response());
+    challengeStack.add(new Challenge_GetTasks());
     challengeStack.add(new Challenge_Sandbox());
     currentChallengeIndex = 0;
   }

--- a/simulation/Challenge_GetTasks.pde
+++ b/simulation/Challenge_GetTasks.pde
@@ -1,0 +1,13 @@
+class Challenge_GetTasks extends Challenge {
+  Challenge_GetTasks() {
+    world.addPerson();
+    title = "Challenge 2 - Get Tasks";
+    description = "When a person has nothing to do, they ask for a task. They do this by making a request to:\n\n/tasks\n\nThis should be a JSON object which includes an array of tasks:\n\n{\n  tasks: []\n}";
+  }
+
+  void listen(Event event) {
+    if (event instanceof GetTasksSuccessEvent) {
+      markComplete();
+    }
+  }
+}

--- a/simulation/Event.pde
+++ b/simulation/Event.pde
@@ -4,3 +4,8 @@ class ClientSuccessEvent extends Event {
   ClientSuccessEvent() {
   }
 }
+
+class GetTasksSuccessEvent extends Event {
+  GetTasksSuccessEvent() {
+  }
+}

--- a/simulation/PersonClient.pde
+++ b/simulation/PersonClient.pde
@@ -56,6 +56,7 @@ class PersonClient extends Client {
     get.send();
     ArrayList<Task> tasks = new ArrayList<Task>();
     if (get.status == 200 && get.getContent() != null) {
+      person.world.eventStream.emit(new GetTasksSuccessEvent());
       JSONObject jsonResponse = parseJSONObject(get.getContent());
       JSONArray jsonTasks = jsonResponse.getJSONArray("tasks");
 


### PR DESCRIPTION
Introduce a second challenge which requires the user respond to GET `/tasks` and return a valid JSON object:

```json
{
  "tasks": []
}
```

Includes an example solution.